### PR TITLE
Fix desktop starter

### DIFF
--- a/files/extras/desktop-starter/Autodesk Fusion 360.desktop
+++ b/files/extras/desktop-starter/Autodesk Fusion 360.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Autodesk Fusion 360
 Comment=This program launcher only works if you selected the standard installation when installing Autodesk Fusion 360!
-Exec=xterm -hold -e "cd $HOME/.local/applications/wine/Programs/Autodesk/fusion360-launcher.sh"
+Exec=xterm -hold -e "$HOME/.local/applications/wine/Programs/Autodesk/fusion360-launcher.sh"
 Type=Application
 Categories=Development;Graphics;Science
 StartupNotify=true


### PR DESCRIPTION
Recently in https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/commit/2a184cfe472ce914f80e95c7e44467ad12e9272f a change was made which made it invalid (you can't `cd` into file).

I did test it locally yesterday :)

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.
