### PR TITLE
Fix flatpak installation

### DIFF
--- a/files/scripts/development-branch/flatpak/flatpak-install.sh
+++ b/files/scripts/development-branch/flatpak/flatpak-install.sh
@@ -88,8 +88,8 @@ function fusion360-flatpak {
     mkdir -p "$HOME/.wineprefixes/fusion360/INSTALLDIR/data/fusion360"
     cd "$HOME/.wineprefixes/fusion360/INSTALLDIR/data/fusion360"
     wget https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Admin%20Install.exe -O Fusion360installer.exe
-    wine Fusion\ 360\ Admin\ Install.exe -p deploy -g -f log.txt --quiet
-    wine Fusion\ 360\ Admin\ Install.exe -p deploy -g -f log.txt --quiet
+    wine Fusion360installer.exe -p deploy -g -f log.txt --quiet
+    wine Fusion360installer.exe -p deploy -g -f log.txt --quiet
     mkdir -p "$HOME/.local/share/flatpak-wine619/default/drive_c/users/steamuser/Application Data/Autodesk/Neutron Platform/"
 
 cat > "$HOME/.local/share/flatpak-wine619/default/drive_c/users/steamuser/Application Data/Autodesk/Neutron Platform/Options/NMachineSpecificOptions.xml" << "E"


### PR DESCRIPTION
There's a mismatch between downloaded and executed file in function "fusion360-flatpak" which prevents the installer from working.

## 📝 Description
Changed the name of the file to be ran, so that it matches the downloaded one.

## 📑 Context
It was running the wrong (not existing) one.

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->

### 🔗 Link to story (if available)
<!--- Add story URL here -->
