### PR TITLE
Fix #160

### DIFF
--- a/files/extras/desktop-starter/fusion360-launcher.sh
+++ b/files/extras/desktop-starter/fusion360-launcher.sh
@@ -19,7 +19,7 @@ function fusion360-starter {
 
 # You must change the first part ($HOME/.wineprefixes/fusion360) and the last part (WINEPREFIX="$HOME/.wineprefixes/fusion360") when you have installed Autodesk Fusion 360 into another directory!
 
-launcher="$(find $HOME/.wineprefixes/fusion360 -name Fusion360.exe -printf "%T+ %p" | sort -r 2>&1 | head -n 1 | sed -r 's/.+0000000000 (.+)/\1/')" && WINEPREFIX="$HOME/.wineprefixes/fusion360" wine "$launcher"
+launcher="$(find $HOME/.wineprefixes/fusion360 -name Fusion360.exe -printf "%T+ %p\n" | sort -r 2>&1 | head -n 1 | sed -r 's/.+0000000000 (.+)/\1/')" && WINEPREFIX="$HOME/.wineprefixes/fusion360" wine "$launcher"
 
 }
 


### PR DESCRIPTION
Add linebreak in find output format string, as not all find versions add by default.

## 📑 Context
See https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/issues/160

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Tested the changes locally.
