### PR TITLE
Corrected links to anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,9 @@
 </br>
 🔹 Check, if your <a href="https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/tree/main/files/extras/network/etc">network settings</a> are correctly configured!
 </br>
-🔹 Check, if your system meets all <a href="https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/edit/main/files/builds/development-branch/README.md#-what-are-the-system-requirements-for-autodesk-fusion-360">requirements</a>!
+🔹 Check, if your system meets all <a href="#fusion360-requirements-2">requirements</a>!
 </br>
-🔹 You need an active Fusion 360 <a href="https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/edit/main/files/builds/development-branch/README.md#-how-much-does-fusion-360-cost">license</a>!
+🔹 You need an active Fusion 360 <a href="#-how-much-does-fusion-360-cost">license</a>!
 </br></br>
 🔹 Open a terminal and run this command:
 </br></br>


### PR DESCRIPTION
Corrected the following two links:
Check, if your system meets all requirements!
You need an active Fusion 360 license!

## 📝 Description
Links pointed to the 'edit' pages.  Converted to relative links for the current document.
Autodesk-Fusion-360-for-Linux/**edit**/main/files/builds/development-branch/README.md#-what-are-the-system-requirements-for-autodesk-fusion-360
Autodesk-Fusion-360-for-Linux/**edit**/main/files/builds/development-branch/README.md#-how-much-does-fusion-360-cost

## 📑 Context
Invalid links

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [ ] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
N/A

### 🔗 Link to story (if available)
N/A
