### PR TITLE
Fix error "No internet connection possible"

### DIFF
--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -7,8 +7,8 @@
 # Author URI:   https://cryinkfly.com                                                              #
 # License:      MIT                                                                                #
 # Copyright (c) 2020-2022                                                                          #
-# Time/Date:    14:15/02.02.2023                                                                   #
-# Version:      1.8.5                                                                              #
+# Time/Date:    09:30/26.02.2023                                                                   #
+# Version:      1.8.6                                                                              #
 ####################################################################################################
 
 # Path: /$HOME/.fusion360/bin/install.sh
@@ -448,7 +448,7 @@ function SP_FUSION360_INSTALL {
   WINEPREFIX="$WP_DIRECTORY" sh "$SP_PATH/bin/winetricks" -q cjkfonts
   sleep 5s
   SP_DXVK_OPENGL_1
-  # We must set to Windows 10 again because some other winetricks sometimes set it back to Windows XP
+  # We must set to Windows 10 again because some other winetricks sometimes set it back to Windows XP!
   WINEPREFIX="$WP_DIRECTORY" sh "$SP_PATH/bin/winetricks" -q win10
   sleep 5s
   # We must copy the EXE-file directly in the Wineprefix folder (Sandbox-Mode)!

--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -448,6 +448,9 @@ function SP_FUSION360_INSTALL {
   WINEPREFIX="$WP_DIRECTORY" sh "$SP_PATH/bin/winetricks" -q cjkfonts
   sleep 5s
   SP_DXVK_OPENGL_1
+  # We must set to Windows 10 again because some other winetricks sometimes set it back to Windows XP
+  WINEPREFIX="$WP_DIRECTORY" sh "$SP_PATH/bin/winetricks" -q win10
+  sleep 5s
   # We must copy the EXE-file directly in the Wineprefix folder (Sandbox-Mode)!
   cp "$SP_PATH/downloads/Fusion360installer.exe" "$WP_DIRECTORY/drive_c/users/$USER/Downloads"
   # This start and stop the installer automatically after a time!


### PR DESCRIPTION
## 📝 Description
Enforce that the Windows version is really Windows 10 after all the other `winetricks` have been applied.

## 📑 Context
Some `winetricks` that get applied in `install.sh` seem to set the Windows version to Windows XP temporarily without properly setting it back to Windows 10 afterwards. This leads to Fusion 360 not starting anymore but complaining about not being able to connect to the internet.  
This PR should fix #300.

I have not updated the version number or time and date in the script because I was not sure what version number you would prefer or if there are other files that need updating - feel free to add anything to the PR as you like. Thanks!

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.

### 🔗 Link to story (if available)
#300 
