### PR TITLE
Patch to get installer working again, using a pre SSO admin installer

### DIFF
--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -281,7 +281,7 @@ function SP_FUSION360_INSTALLER_LOAD {
     echo "The Autodesk Fusion 360 installer exist!"
   else
     echo "The Autodesk Fusion 360 installer doesn't exist and will be downloaded for you!"
-    wget https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Admin%20Install.exe -O Fusion360installer.exe
+    wget -T 15 -t 0 -N -c 'https://web.archive.org/web/20230317210714id_/https://dl.appstreaming.autodesk.com/production/installers/Fusion 360 Admin Install.exe' -O Fusion360installer.exe
     mv "Fusion360installer.exe" "$SP_PATH/downloads/Fusion360installer.exe"
   fi
 }

--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -554,6 +554,12 @@ function OS_UBUNTU_22 {
   sudo apt-add-repository 'deb https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_22.04/ ./'
 }
 
+function OS_UBUNTU_23 {
+  sudo add-apt-repository -r 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
+  wget -q https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_23.04/Release.key -O Release.key -O- | sudo apt-key add -
+  sudo apt-add-repository 'deb https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_23.04/ ./'
+}
+
 ###############################################################################################################################################################
 
 function FEDORA_BASED_1 {
@@ -1014,6 +1020,11 @@ elif [[ $SP_OS = "Linux Mint 21.x" ]]; then
     DEBIAN_BASED_1
     OS_UBUNTU_22
     DEBIAN_BASED_1
+elif [[ $SP_OS = "Linux Mint 22.x" ]]; then
+    echo "Linux Mint 22.x"
+    DEBIAN_BASED_1
+    OS_UBUNTU_23
+    DEBIAN_BASED_1
 elif [[ $SP_OS = "Manjaro Linux" ]]; then
     echo "Manjaro Linux"
     OS_ARCHLINUX
@@ -1049,6 +1060,11 @@ elif [[ $SP_OS = "Ubuntu 22.04" ]]; then
     echo "Ubuntu 22.04"
     DEBIAN_BASED_1
     OS_UBUNTU_22
+    DEBIAN_BASED_2
+elif [[ $SP_OS = "Ubuntu 23.04" ]]; then
+    echo "Ubuntu 23.04"
+    DEBIAN_BASED_1
+    OS_UBUNTU_23
     DEBIAN_BASED_2
 elif [[ $SP_OS = "Void Linux" ]]; then
     echo "Void Linux"

--- a/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
+++ b/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Odstraňte aktuální Wineprefix ze svého
 SP_OS_TITLE="Linux distribuce - Konfigurace"
 SP_OS_LABEL_1="V tomto kroku nyní můžete vybrat svou distribuci Linuxu a nainstalovat potřebné balíčky pro instalaci."
 SP_OS_LABEL_2="Linux distribuce:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/de-DE/locale-de.sh
+++ b/files/builds/stable-branch/locale/de-DE/locale-de.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Entfernen Sie eine aktuelle Wineprefix von
 SP_OS_TITLE="Linux-Distribution - Konfiguration"
 SP_OS_LABEL_1="In diesem Schritt können Sie nun Ihre Linux-Distribution auswählen, um die benötigten Pakete für die Installation zu installieren."
 SP_OS_LABEL_2="Linux-Distribution:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/en-US/locale-en.sh
+++ b/files/builds/stable-branch/locale/en-US/locale-en.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Remove a current Wineprefix from your syst
 SP_OS_TITLE="Linux distribution - Configuration"
 SP_OS_LABEL_1="In this step you can now select your Linux distribution to install the required packages for the installation."
 SP_OS_LABEL_2="Linux distribution:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/es-ES/locale-es.sh
+++ b/files/builds/stable-branch/locale/es-ES/locale-es.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="¡Elimine un Wineprefix actual de su siste
 SP_OS_TITLE="Distribución Linux - Configuración"
 SP_OS_LABEL_1="En este paso ahora puede seleccionar su distribución de Linux para instalar los paquetes necesarios para la instalación."
 SP_OS_LABEL_2="Distribución de Linux:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
+++ b/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Supprimer un préfixe Wine actuel de votre
 SP_OS_TITLE="Distribution Linux - Configuration"
 SP_OS_LABEL_1="Dans cette étape, vous pouvez maintenant sélectionner votre distribution Linux pour installer les packages requis pour l'installation."
 SP_OS_LABEL_2="Répartition Linux :"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/it-IT/locale-it.sh
+++ b/files/builds/stable-branch/locale/it-IT/locale-it.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Rimuovi un Wineprefix corrente dal tuo sis
 SP_OS_TITLE="Distribuzione Linux - Configurazione"
 SP_OS_LABEL_1="In questo passaggio puoi ora selezionare la tua distribuzione Linux per installare i pacchetti richiesti per l'installazione."
 SP_OS_LABEL_2="Distribuzione Linux:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
+++ b/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="システムから現在のWineprefixを�
 SP_OS_TITLE="Linuxディストリビューション-構成"
 SP_OS_LABEL_1="このステップでは、Linuxディストリビューションを選択して、インストールに必要なパッケージをインストールできます。"
 SP_OS_LABEL_2="Linuxディストリビューション："
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
+++ b/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="시스템에서 현재 Wineprefix를 제�
 SP_OS_TITLE="Linux 배포 - 구성"
 SP_OS_LABEL_1="이 단계에서는 이제 Linux 배포판을 선택하여 설치에 필요한 패키지를 설치할 수 있습니다."
 SP_OS_LABEL_2="Linux 배포판:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
+++ b/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="从您的系统中删除当前的 Winepref
 SP_OS_TITLE="Linux 发行版 - 配置"
 SP_OS_LABEL_1="在此步骤中，您现在可以选择您的 Linux 发行版来安装安装所需的软件包。"
 SP_OS_LABEL_2="Linux 发行版："
-SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,Debian 10,Debian 11,EndeavourOS,Fedora 35,Fedora 36,Linux Mint 19.x,Linux Mint 20.x,Manjaro Linux,openSUSE Leap 15.3,openSUSE Leap 15.4,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 18.04,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.04,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 


### PR DESCRIPTION
## 📝 Description
Changed Admin installer to download from Wayback machine, to the last version Pre SSO update
Added support for Ubuntu 23.04 

## 📑 Context
<!--- Why is this change required? What problem does it solve? -->

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [ ] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->

### 🔗 Link to story (if available)
<!--- Add story URL here -->
