### PR TITLE
Add a command to use an older version of Fusion 360 until #319 is fixed

### DIFF
--- a/README-cs_CZ.md
+++ b/README-cs_CZ.md
@@ -315,7 +315,14 @@
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
-    
+</br>
+
+🔹 Fusion 360 pro Linux je momentálně nefunkční. Autodesk vyžaduje, aby váš prohlížeč otevřel přihlašovací stránku Fusion 360, ale zatím nemá řešení tohoto problému. Mějte s námi trpělivost, když zkoumáme a vyvíjíme řešení. Mezitím můžete tento příkaz použít k instalaci Fusion 360 pro Linux se starší verzí Fusion 360, která nevyžaduje přihlášení do prohlížeče:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
 🔹 Nebo nainstalujete a použijete Autodesk Fusion 360 jako aplikaci Flatpak: 
 
     https://usebottles.com/app/#fusion360    

--- a/README-de_DE.md
+++ b/README-de_DE.md
@@ -315,7 +315,14 @@
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
-    
+</br>
+
+🔹 Derzeit ist Fusion 360 für Linux defekt. Autodesk erfordert, dass Ihr Browser eine Seite öffnet, um sich bei Fusion 360 anzumelden, aber es gibt noch keine Lösung für dieses Problem. Bitte haben Sie Geduld mit uns, während wir nach einer Lösung suchen und diese entwickeln. In der Zwischenzeit können Sie diesen Befehl verwenden, um Fusion 360 für Linux mit einer älteren Version von Fusion 360 zu installieren, für die keine Browseranmeldung erforderlich ist:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
 🔹 Oder Sie installieren und verwenden Autodesk Fusion 360 als Flatpak-App:
 
     https://usebottles.com/app/#fusion360 

--- a/README-es_ES.md
+++ b/README-es_ES.md
@@ -315,7 +315,15 @@
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
-    
+</br>
+
+🔹 Actualmente, Fusion 360 para Linux no funciona. Autodesk requiere que su navegador abra una página para iniciar sesión en Fusion 360, pero aún no tiene una solución para este problema. Tenga paciencia con nosotros mientras investigamos y desarrollamos una solución. Mientras tanto, puede usar este comando para instalar Fusion 360 para Linux con una versión anterior de Fusion 360 que no requiere iniciar sesión en el navegador:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
+
 🔹 O instala y usa Autodesk Fusion 360 como una aplicación Flatpak:
 
     https://usebottles.com/app/#fusion360

--- a/README-fr_FR.md
+++ b/README-fr_FR.md
@@ -315,7 +315,14 @@
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
-    
+</br>
+
+🔹 Actuellement, Fusion 360 pour Linux est en panne. Autodesk nécessite que votre navigateur ouvre une page pour se connecter à Fusion 360, mais n'a pas encore de solution à ce problème. Veuillez patienter avec nous pendant que nous recherchons et développons une solution. En attendant, vous pouvez utiliser cette commande pour installer Fusion 360 pour Linux avec une ancienne version de Fusion 360 qui ne nécessite pas de connexion au navigateur:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
 🔹 Ou vous installez et utilisez Autodesk Fusion 360 en tant qu'application Flatpak :
 
      https://usebottles.com/app/#fusion360

--- a/README-it_IT.md
+++ b/README-it_IT.md
@@ -315,7 +315,14 @@
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
-    
+</br>
+
+🔹 Attualmente, Fusion 360 per Linux non funziona. Autodesk richiede che il browser si apra a una pagina per accedere a Fusion 360, ma non ha ancora una soluzione per questo problema. Abbi pazienza mentre cerchiamo e sviluppiamo una soluzione. Nel frattempo, puoi utilizzare questo comando per installare Fusion 360 per Linux con una versione precedente di Fusion 360 che non richiede l'accesso al browser:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
 🔹 Oppure installi e utilizzi Autodesk Fusion 360 come app Flatpak:
 
      https://usebottles.com/app/#fusion360

--- a/README-ja_JP.md
+++ b/README-ja_JP.md
@@ -315,7 +315,14 @@
 </br> </br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
-    
+</br>
+
+🔹 現在、Linux 用の Fusion 360 は壊れています。 Autodesk では、ブラウザで Fusion 360 にログインするページを開く必要がありますが、この問題の解決策はまだありません。解決策を研究および開発していますので、しばらくお待ちください。それまでの間、次のコマンドを使用して、ブラウザ サインインを必要としない古いバージョンの Fusion 360 で Linux 用の Fusion 360 をインストールできます。
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
 🔹または、AutodeskFusion360をFlatpakアプリとしてインストールして使用します。
 
      https://usebottles.com/app/#fusion360

--- a/README-ko_KR.md
+++ b/README-ko_KR.md
@@ -315,7 +315,14 @@
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
-    
+</br>
+
+🔹 현재, Linux용 Fusion 360은 작동하지 않습니다. Autodesk는 Fusion 360에 로그인하기 위해 브라우저를 열도록 요구하지만, 이 문제에 대한 해결책은 아직 없습니다. 문제를 연구하고 해결책을 개발하는 동안 양해 부탁드립니다. 한편, 브라우저 로그인이 필요하지 않은 이전 버전의 Fusion 360으로 Linux용 Fusion 360을 설치하려면 이 명령을 사용할 수 있습니다:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
 🔹 또는 Autodesk Fusion 360을 Flatpak 앱으로 설치하고 사용합니다.
 
      https://usebottles.com/app/#fusion360

--- a/README-ru_RU.md
+++ b/README-ru_RU.md
@@ -315,6 +315,13 @@
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
+🔹 В настоящее время Fusion 360 для Linux не работает. Autodesk требует от вашего браузера открыть страницу для входа в Fusion 360, но пока не имеет решения для этой проблемы. Пожалуйста, подождите, пока мы исследуем и разработаем решение. В то же время, вы можете использовать эту команду для установки Fusion 360 для Linux с более старой версией Fusion 360, которая не требует входа через браузер:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
 
 🔹 Или вы устанавливаете и используете Autodesk Fusion 360 в качестве приложения Flatpak:
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -315,7 +315,14 @@
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
-    
+</br>
+
+🔹 目前，适用于 Linux 的 Fusion 360 已损坏。 Autodesk 需要您的浏览器打开一个页面才能登录 Fusion 360，但目前还没有针对此问题的解决方案。请耐心等待我们研究和开发解决方案。同时，您可以使用此命令安装适用于 Linux 的 Fusion 360 以及不需要浏览器登录的旧版本 Fusion 360:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
 🔹 或者您安装 Autodesk Fusion 360 并将其用作 Flatpak 应用程序：
 
     https://usebottles.com/app/#fusion360    

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
 </br>
 
-🔹 Currently, Fusion 360 for Linux is broken. Autodesk requires your browser to open to a page to log in to Fusion 360, but do not yet have a solution for this problem. Please bear with us as we research and develop a solution. In the meantime, you can use this command to install Fusion 360 for Linux with an older version of Fusion 360 that does not require browser sign-in:
+🔹 Currently, Fusion 360 for Linux is broken. Autodesk requires your browser to open to a page to log in to Fusion 360, but we do not yet have a way to open the link in a browser. Please bear with us as we research and develop a solution. In the meantime, you can use this command to install Fusion 360 for Linux with an older version of Fusion 360 that does not require browser sign-in:
 </br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh

--- a/README.md
+++ b/README.md
@@ -312,9 +312,15 @@
 🔹 You need an active Fusion 360 <a href="#-how-much-does-fusion-360-cost">license</a>!
 </br></br>
 🔹 Open a terminal and run this command:
-</br></br>
 
     mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
+
+🔹 Currently, Fusion 360 for Linux is broken. Autodesk requires your browser to open to a page to log in to Fusion 360, but do not yet have a solution for this problem. Please bear with us as we research and develop a solution. In the meantime, you can use this command to install Fusion 360 for Linux with an older version of Fusion 360 that does not require browser sign-in:
+</br></br>
+
+    mkdir -p "$HOME/.fusion360/bin" && cd "$HOME/.fusion360/bin" && wget -N https://raw.githubusercontent.com/alextrical/Autodesk-Fusion-360-for-Linux/main/files/builds/stable-branch/bin/install.sh && chmod +x install.sh && ./install.sh
+</br>
 
 🔹 Or you install and use Autodesk Fusion 360 as a Flatpak app: 
 

--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -281,7 +281,7 @@ function SP_FUSION360_INSTALLER_LOAD {
     echo "The Autodesk Fusion 360 installer exist!"
   else
     echo "The Autodesk Fusion 360 installer doesn't exist and will be downloaded for you!"
-    wget https://dl.appstreaming.autodesk.com/production/installers/Fusion%20360%20Admin%20Install.exe -O Fusion360installer.exe
+    wget -T 15 -t 0 -N -c '(link to install file coming)' -O Fusion360installer.exe
     mv "Fusion360installer.exe" "$SP_PATH/downloads/Fusion360installer.exe"
   fi
 }


### PR DESCRIPTION
## 📝 Description
<!--- Describe your changes in detail -->

Adds a link to a tested version of Fusion 360 for Linux that uses an older version of Fusion 360 from the Wayback Machine. This resolves issue #319 and PR #322. Translations for other languages have been verified. New documentation has been integrated correctly into the readme.

## 📑 Context
<!--- Why is this change required? What problem does it solve? -->

This change gives Fusion 360 for Linux real function until we can fix issue #319. It solves the welcome browser not opening because it uses and older version for Fusion 360.

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [x] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->
![image](https://user-images.githubusercontent.com/108906631/234741747-8190556c-1178-494c-9ab0-9f764e9c4404.png)

### 🔗 Link to story (if available)
<!--- Add story URL here -->
