### PR TITLE
Misc fixes

### DIFF
--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -519,8 +519,8 @@ function DEBIAN_BASED_1 {
 
 function DEBIAN_BASED_2 {
   sudo apt-get update
-  sudo apt-get install p7zip p7zip-full p7zip-rar curl winbind cabextract wget
-  sudo apt-get install --install-recommends winehq-staging
+  sudo apt-get install -y p7zip p7zip-full p7zip-rar curl winbind cabextract wget
+  sudo apt-get install -y --install-recommends winehq-staging
   SP_FUSION360_INSTALL
 }
 

--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -986,12 +986,12 @@ elif [[ $SP_OS = "Debian 10" ]]; then
     echo "Debian 10"
     DEBIAN_BASED_1
     OS_DEBIAN_10
-    DEBIAN_BASED_1
+    DEBIAN_BASED_2
 elif [[ $SP_OS = "Debian 11" ]]; then
     echo "Debian 11"
     DEBIAN_BASED_1
     OS_DEBIAN_11
-    DEBIAN_BASED_1
+    DEBIAN_BASED_2
 elif [[ $SP_OS = "EndeavourOS" ]]; then
     echo "EndeavourOS"
     OS_ARCHLINUX
@@ -1014,17 +1014,17 @@ elif [[ $SP_OS = "Linux Mint 20.x" ]]; then
     echo "Linux Mint 20.x"
     DEBIAN_BASED_1
     OS_UBUNTU_20
-    DEBIAN_BASED_1
+    DEBIAN_BASED_2
 elif [[ $SP_OS = "Linux Mint 21.x" ]]; then
     echo "Linux Mint 21.x"
     DEBIAN_BASED_1
     OS_UBUNTU_22
-    DEBIAN_BASED_1
+    DEBIAN_BASED_2
 elif [[ $SP_OS = "Linux Mint 22.x" ]]; then
     echo "Linux Mint 22.x"
     DEBIAN_BASED_1
     OS_UBUNTU_23
-    DEBIAN_BASED_1
+    DEBIAN_BASED_2
 elif [[ $SP_OS = "Manjaro Linux" ]]; then
     echo "Manjaro Linux"
     OS_ARCHLINUX

--- a/files/builds/stable-branch/locale/locale.sh
+++ b/files/builds/stable-branch/locale/locale.sh
@@ -35,24 +35,6 @@ function load-locale-languages {
   chmod +x $SP_PATH/locale/ko-KR/locale-ko.sh
   wget -N -P $SP_PATH/locale/zh-CN/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
   chmod +x $SP_PATH/locale/zh-CN/locale-zh.sh
-  wget -N -P $SP_PATH/locale/cs-CZ/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
-  chmod +x $SP_PATH/locale/cs-CZ/locale-cs.sh
-  wget -N -P $SP_PATH/locale/de-DE/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/de-DE/locale-de.sh
-  chmod +x $SP_PATH/locale/de-DE/locale-de.sh
-  wget -N -P $SP_PATH/locale/en-US/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/en-US/locale-en.sh
-  chmod +x $SP_PATH/locale/en-US/locale-en.sh
-  wget -N -P $SP_PATH/locale/es-ES/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/es-ES/locale-es.sh
-  chmod +x $SP_PATH/locale/es-ES/locale-es.sh
-  wget -N -P $SP_PATH/locale/fr-FR/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
-  chmod +x $SP_PATH/locale/fr-FR/locale-fr.sh
-  wget -N -P $SP_PATH/locale/it-IT/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/it-IT/locale-it.sh
-  chmod +x $SP_PATH/locale/it-IT/locale-it.sh
-  wget -N -P $SP_PATH/locale/ja-JP/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
-  chmod +x $SP_PATH/locale/ja-JP/locale-ja.sh
-  wget -N -P $SP_PATH/locale/ko-KR/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
-  chmod +x $SP_PATH/locale/ko-KR/locale-ko.sh
-  wget -N -P $SP_PATH/locale/zh-CN/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
-  chmod +x $SP_PATH/locale/zh-CN/locale-zh.sh
 }
 
 ###############################################################################################################################################################
@@ -68,30 +50,12 @@ function load-locale-licenses {
   wget -N -P $SP_PATH/locale/ja-JP/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/ja-JP/license-ja.txt
   wget -N -P $SP_PATH/locale/ko-KR/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/ko-KR/license-ko.txt
   wget -N -P $SP_PATH/locale/zh-CN/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/zh-CN/license-zh.txt
-  wget -N -P $SP_PATH/locale/cs-CZ/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/cs-CZ/license-cs.txt
-  wget -N -P $SP_PATH/locale/de-DE/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/de-DE/license-de.txt
-  wget -N -P $SP_PATH/locale/en-US/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/en-US/license-en.txt
-  wget -N -P $SP_PATH/locale/es-ES/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/es-ES/license-es.txt
-  wget -N -P $SP_PATH/locale/fr-FR/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/fr-FR/license-fr.txt
-  wget -N -P $SP_PATH/locale/it-IT/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/it-IT/license-it.txt
-  wget -N -P $SP_PATH/locale/ja-JP/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/ja-JP/license-ja.txt
-  wget -N -P $SP_PATH/locale/ko-KR/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/ko-KR/license-ko.txt
-  wget -N -P $SP_PATH/locale/zh-CN/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/zh-CN/license-zh.txt
 }
 
 ###############################################################################################################################################################
 
 # Load & Save the translations of the extensions into the folders!
 function load-locale-extensions {
-  wget -N -P $SP_PATH/locale/cs-CZ/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/cs-CZ/extensions-cs.txt
-  wget -N -P $SP_PATH/locale/de-DE/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/de-DE/extensions-de.txt
-  wget -N -P $SP_PATH/locale/en-US/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/en-US/extensions-en.txt
-  wget -N -P $SP_PATH/locale/es-ES/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/es-ES/extensions-es.txt
-  wget -N -P $SP_PATH/locale/fr-FR/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/fr-FR/extensions-fr.txt
-  wget -N -P $SP_PATH/locale/it-IT/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/it-IT/extensions-it.txt
-  wget -N -P $SP_PATH/locale/ja-JP/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/ja-JP/extensions-ja.txt
-  wget -N -P $SP_PATH/locale/ko-KR/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/ko-KR/extensions-ko.txt
-  wget -N -P $SP_PATH/locale/zh-CN/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/zh-CN/extensions-zh.txt
   wget -N -P $SP_PATH/locale/cs-CZ/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/cs-CZ/extensions-cs.txt
   wget -N -P $SP_PATH/locale/de-DE/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/de-DE/extensions-de.txt
   wget -N -P $SP_PATH/locale/en-US/ https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/raw/main/files/builds/stable-branch/locale/en-US/extensions-en.txt


### PR DESCRIPTION
## 📝 Description
<!--- Describe your changes in detail -->

Fixes to problems I encountered while running the script on Debian 11:

* DEBIAN_BASED_2 is never called, so wine-staging does not get installed on Debian based systems
* Locale files are downloaded twice
* apt-get install fails / is skipped, because -y is not passed

## 📑 Context
<!--- Why is this change required? What problem does it solve? -->

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [X] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.
