### PR TITLE
bin/install.sh: Add missing dependencies

### DIFF
--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -41,6 +41,9 @@ SP_FUSION360_CHANGE=0
 
 REQUIRED_COMMANDS=(
     "yad"
+    "wine"
+    "wget"
+    "cabextract"
 )
 
 # URL to download Fusion360Installer.exe

--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -41,9 +41,7 @@ SP_FUSION360_CHANGE=0
 
 REQUIRED_COMMANDS=(
     "yad"
-    "wine"
     "wget"
-    "cabextract"
 )
 
 # URL to download Fusion360Installer.exe


### PR DESCRIPTION
ye, that ain't enough chief

## 📝 Description
<!--- Describe your changes in detail -->

* needs `wget` for downloads (don't assume that everyone has it!)
* `cabextract` seems to be dependency for `wine msiexec`
* depends on `wine`

## 📑 Context
<!--- Why is this change required? What problem does it solve? -->

Running on NixOS and lack of quality assurance to exit when it should

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [-] Updated tests for this change.
- [X] Tested the changes locally.
- [-] Updated documentation.
- [-] Change version number.
- [-] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->

### 🔗 Link to story (if available)
<!--- Add story URL here -->
