### PR TITLE
Improve yad user experience for app startup

### DIFF
--- a/files/builds/stable-branch/bin/update.sh
+++ b/files/builds/stable-branch/bin/update.sh
@@ -126,7 +126,7 @@ function UP_FUSION360_INSTALL_STOP_2 {
 
 # The user get a informationt that no newer version of Autodesk Fusion 360 was found!
 function UP_NO_UPDATE_INFO {
-  yad --title="$UP_TITLE" --text="$UP_NO_UPDATE_INFO_LABEL" --text-align=center
+  yad --image dialog-information --title="$UP_TITLE" --text="$UP_NO_UPDATE_INFO_LABEL" --text-align=center --button=gtk-ok:1
   LAUNCHER_RUN_FUSION360
 }
 
@@ -134,7 +134,7 @@ function UP_NO_UPDATE_INFO {
 
 # The user will be informed that he is skipping the update!
 function UP_SKIP_INFO {
-  yad --title="$UP_TITLE" --text="$UP_SKIP_INFO_LABEL" --text-align=center
+  yad --image dialog-information --title="$UP_TITLE" --text="$UP_SKIP_INFO_LABEL" --text-align=center --button=gtk-ok:1
   LAUNCHER_RUN_FUSION360
 }
 
@@ -142,7 +142,7 @@ function UP_SKIP_INFO {
 
 # The user get a informationt that there is no connection to the server!
 function UP_NO_CONNECTION_WARNING {
-  yad --title="$UP_TITLE" --text="$UP_NO_CONNECTION_WARNING_LABEL" --text-align=center
+  yad --image dialog-warning --title="$UP_TITLE" --text="$UP_NO_CONNECTION_WARNING_LABEL" --text-align=center --button=gtk-ok:1
   LAUNCHER_RUN_FUSION360
 }
 
@@ -150,7 +150,7 @@ function UP_NO_CONNECTION_WARNING {
 
 # The user will be asked if he wants to update or not.
 function UP_QUESTION {
-  yad --title="$UP_TITLE" --text="$UP_QUESTION_LABEL" --text-align=center --button=gtk-cancel:0 --button=gtk-ok:1
+  yad --image dialog-question --title="$UP_TITLE" --text="$UP_QUESTION_LABEL" --text-align=center --button=gtk-no:0 --button=gtk-yes:1
 
   answer=$?
 
@@ -166,15 +166,8 @@ function UP_QUESTION {
 
 # A progress bar is displayed here.
 function UP_PROGRESS {
-  UP_PROGRESS_MAIN () {
-    echo "30" ; sleep 5
-    echo "50" ; sleep 1
-    echo "UP_PROGRESS_LABEL_2" ; sleep 5
-    echo "100" ; sleep 3
-    echo "UP_PROGRESS_LABEL_3" ; sleep 1
-  }
 
-  UP_PROGRESS_MAIN | yad --title="$UP_TITLE" --progress --progress-text "$UP_PROGRESS_LABEL_1" --percentage=0 --button=gtk-cancel:0 --button=gtk-ok:1
+  yad --image dialog-question --title="$UP_TITLE" --text "$UP_WANT_TO_CHECK_FOR_UPDATES" --text-align=center --button=gtk-no:0 --button=gtk-yes:1
 
   ret=$?
 

--- a/files/builds/stable-branch/bin/update.sh
+++ b/files/builds/stable-branch/bin/update.sh
@@ -164,9 +164,8 @@ function UP_QUESTION {
 
 ###############################################################################################################################################################
 
-# A progress bar is displayed here.
+# A question dialog is displayed here.
 function UP_PROGRESS {
-
   yad --image dialog-question --title="$UP_TITLE" --text "$UP_WANT_TO_CHECK_FOR_UPDATES" --text-align=center --button=gtk-no:0 --button=gtk-yes:1
 
   ret=$?

--- a/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
+++ b/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
@@ -136,9 +136,8 @@ UP_QUESTION_LABEL="Byla vydána nová verze! Chcete provést aktualizaci?"
 
 UP_NO_CONNECTION_WARNING_LABEL="Připojení k serveru nelze navázat! Kontrola nových aktualizací byla přeskočena! Zkontrolujte prosím své internetové připojení!"
 
-UP_PROGRESS_LABEL_1="Připojování k serveru ..."
-UP_PROGRESS_LABEL_2="# Zkontrolovat všechny soubory .."
-UP_PROGRESS_LABEL_3="# Všechny soubory jsou zkontrolovány!"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 bude aktualizován na novější verzi ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
+++ b/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
@@ -129,14 +129,14 @@ SP_COMPLETED_CHECK_LABEL="Spusťte Autodesk Fusion 360"
 
 UP_TITLE="Autodesk Fusion 360 pro Linux - Launcher"
 UP_NO_UPDATE_INFO_LABEL="Nebyla nalezena žádná novější verze, takže váš Autodesk fusion 360 je aktuální!"
-UP_SKIP_INFO_LABEL="Aktualizace byla přeskočena! Aktualizujte prosím svou verzi Autodesk Fusion 360 brzy!"
+UP_SKIP_INFO_LABEL="Aktualizace byla přeskočena! Zvažte prosím příště kontrolu aktualizací."
 UP_SKIP_UPDATE_QUESTION_LABEL="Opravdu chcete přeskočit hledání aktualizace Autodesk Fusion 360?"
 
 UP_QUESTION_LABEL="Byla vydána nová verze! Chcete provést aktualizaci?"
 
 UP_NO_CONNECTION_WARNING_LABEL="Připojení k serveru nelze navázat! Kontrola nových aktualizací byla přeskočena! Zkontrolujte prosím své internetové připojení!"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="Chcete před spuštěním zkontrolovat aktualizace Fusion 360?"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 bude aktualizován na novější verzi ..."
 

--- a/files/builds/stable-branch/locale/de-DE/locale-de.sh
+++ b/files/builds/stable-branch/locale/de-DE/locale-de.sh
@@ -136,9 +136,8 @@ UP_QUESTION_LABEL="Eine neue Version wurde veröffentlicht! Möchten Sie jetzt a
 
 UP_NO_CONNECTION_WARNING_LABEL="Die Verbindung zum Server konnte nicht hergestellt werden! Die Suche nach neuen Updates wurde übersprungen! Bitte überprüfen Sie Ihre Internetverbindung!"
 
-UP_PROGRESS_LABEL_1="Verbinde mit dem Server ..."
-UP_PROGRESS_LABEL_2="# Alle Dateien werden geprüft .."
-UP_PROGRESS_LABEL_3="# Alle Dateien wurden geprüft!"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 wird auf eine neuere Version aktualisiert ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/de-DE/locale-de.sh
+++ b/files/builds/stable-branch/locale/de-DE/locale-de.sh
@@ -129,14 +129,14 @@ SP_COMPLETED_CHECK_LABEL="Autodesk Fusion 360 ausführen"
 
 UP_TITLE="Autodesk Fusion 360 für Linux – Launcher"
 UP_NO_UPDATE_INFO_LABEL="Es wurde keine neuere Version gefunden, daher ist Ihr Autodesk Fusion 360 auf dem neuesten Stand!"
-UP_SKIP_INFO_LABEL="Das Update wurde übersprungen! Bitte aktualisieren Sie bald Ihre Autodesk Fusion 360 Version!"
+UP_SKIP_INFO_LABEL="Das Update wurde übersprungen! Bitte schauen Sie beim nächsten Mal nach Updates."
 UP_SKIP_UPDATE_QUESTION_LABEL="Sind Sie sicher, dass Sie die Suche nach einem Autodesk Fusion 360 Update überspringen möchten?"
 
 UP_QUESTION_LABEL="Eine neue Version wurde veröffentlicht! Möchten Sie jetzt aktualisieren?"
 
 UP_NO_CONNECTION_WARNING_LABEL="Die Verbindung zum Server konnte nicht hergestellt werden! Die Suche nach neuen Updates wurde übersprungen! Bitte überprüfen Sie Ihre Internetverbindung!"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="Möchten Sie vor dem Start nach Updates für Fusion 360 suchen?"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 wird auf eine neuere Version aktualisiert ..."
 

--- a/files/builds/stable-branch/locale/en-US/locale-en.sh
+++ b/files/builds/stable-branch/locale/en-US/locale-en.sh
@@ -129,16 +129,18 @@ SP_COMPLETED_CHECK_LABEL="Run Autodesk Fusion 360"
 
 UP_TITLE="Autodesk Fusion 360 for Linux - Launcher"
 UP_NO_UPDATE_INFO_LABEL="No newer version was found, so your Autodesk fusion 360 is up to date!"
-UP_SKIP_INFO_LABEL="The update was skipped! Please update your Autodesk Fusion 360 version soon!"
+UP_SKIP_INFO_LABEL="The update was skipped! Please consider checking for updates next time."
 UP_SKIP_UPDATE_QUESTION_LABEL="Are you sure you want to skip searching for an Autodesk Fusion 360 update?"
 
 UP_QUESTION_LABEL="A new version has been released! Do you want to update now?"
 
 UP_NO_CONNECTION_WARNING_LABEL="The connection to the server could not be established! Checking for new updates has been skipped! Please check your internet connection!"
 
-UP_PROGRESS_LABEL_1="Connecting to the server ..."
-UP_PROGRESS_LABEL_2="# Check all files .."
-UP_PROGRESS_LABEL_3="# All files are checked!"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
+# UP_PROGRESS_LABEL_1="Connecting to the server ..."
+# UP_PROGRESS_LABEL_2="# Check all files .."
+# UP_PROGRESS_LABEL_3="# All files are checked!"
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 will be updated to a newer version ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/en-US/locale-en.sh
+++ b/files/builds/stable-branch/locale/en-US/locale-en.sh
@@ -136,11 +136,12 @@ UP_QUESTION_LABEL="A new version has been released! Do you want to update now?"
 
 UP_NO_CONNECTION_WARNING_LABEL="The connection to the server could not be established! Checking for new updates has been skipped! Please check your internet connection!"
 
+# Added - New question dialog
 UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
 
-# UP_PROGRESS_LABEL_1="Connecting to the server ..."
-# UP_PROGRESS_LABEL_2="# Check all files .."
-# UP_PROGRESS_LABEL_3="# All files are checked!"
+# REMOVED - UP_PROGRESS_LABEL_1="Connecting to the server ..."
+# REMOVED - UP_PROGRESS_LABEL_2="# Check all files .."
+# REMOVED - UP_PROGRESS_LABEL_3="# All files are checked!"
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 will be updated to a newer version ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/en-US/locale-en.sh
+++ b/files/builds/stable-branch/locale/en-US/locale-en.sh
@@ -136,7 +136,7 @@ UP_QUESTION_LABEL="A new version has been released! Do you want to update now?"
 
 UP_NO_CONNECTION_WARNING_LABEL="The connection to the server could not be established! Checking for new updates has been skipped! Please check your internet connection!"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion 360 before launching?"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 will be updated to a newer version ..."
 

--- a/files/builds/stable-branch/locale/en-US/locale-en.sh
+++ b/files/builds/stable-branch/locale/en-US/locale-en.sh
@@ -136,12 +136,8 @@ UP_QUESTION_LABEL="A new version has been released! Do you want to update now?"
 
 UP_NO_CONNECTION_WARNING_LABEL="The connection to the server could not be established! Checking for new updates has been skipped! Please check your internet connection!"
 
-# Added - New question dialog
 UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
 
-# REMOVED - UP_PROGRESS_LABEL_1="Connecting to the server ..."
-# REMOVED - UP_PROGRESS_LABEL_2="# Check all files .."
-# REMOVED - UP_PROGRESS_LABEL_3="# All files are checked!"
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 will be updated to a newer version ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/es-ES/locale-es.sh
+++ b/files/builds/stable-branch/locale/es-ES/locale-es.sh
@@ -133,9 +133,8 @@ UP_QUESTION_LABEL="¡Se ha lanzado una nueva versión! ¿Quiere actualizar ahora
 
 UP_NO_CONNECTION_WARNING_LABEL="¡No se pudo establecer la conexión con el servidor! ¡Se ha omitido la búsqueda de nuevas actualizaciones! ¡Compruebe su conexión a Internet!"
 
-UP_PROGRESS_LABEL_1="Conectando al servidor..."
-UP_PROGRESS_LABEL_2="# Verificar todos los archivos .."
-UP_PROGRESS_LABEL_3="# ¡Todos los archivos están revisados!"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 se actualizará a una versión más reciente ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/es-ES/locale-es.sh
+++ b/files/builds/stable-branch/locale/es-ES/locale-es.sh
@@ -126,14 +126,14 @@ SP_COMPLETED_CHECK_LABEL="Ejecutar Autodesk Fusion 360"
 
 UP_TITLE="Autodesk Fusion 360 para Linux - Iniciador"
 UP_NO_UPDATE_INFO_LABEL="¡No se encontró una versión más nueva, por lo que su Autodesk fusion 360 está actualizado!"
-UP_SKIP_INFO_LABEL="¡Se omitió la actualización! ¡Actualice su versión de Autodesk Fusion 360 pronto!"
+UP_SKIP_INFO_LABEL="¡Se omitió la actualización! Considere buscar actualizaciones la próxima vez."
 UP_SKIP_UPDATE_QUESTION_LABEL="¿Está seguro de que desea omitir la búsqueda de una actualización de Autodesk Fusion 360?"
 
 UP_QUESTION_LABEL="¡Se ha lanzado una nueva versión! ¿Quiere actualizar ahora?"
 
 UP_NO_CONNECTION_WARNING_LABEL="¡No se pudo establecer la conexión con el servidor! ¡Se ha omitido la búsqueda de nuevas actualizaciones! ¡Compruebe su conexión a Internet!"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="¿Le gustaría buscar actualizaciones de Fusion 360 antes del lanzamiento?"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 se actualizará a una versión más reciente ..."
 

--- a/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
+++ b/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
@@ -129,14 +129,14 @@ SP_COMPLETED_CHECK_LABEL="Exécuter Autodesk Fusion 360"
 
 UP_TITLE="Autodesk Fusion 360 pour Linux - Lanceur"
 UP_NO_UPDATE_INFO_LABEL="Aucune version plus récente n'a été trouvée, donc votre Autodesk fusion 360 est à jour !"
-UP_SKIP_INFO_LABEL="La mise à jour a été ignorée ! Veuillez mettre à jour votre version d'Autodesk Fusion 360 bientôt !"
+UP_SKIP_INFO_LABEL="La mise à jour a été ignorée ! Veuillez envisager de vérifier les mises à jour la prochaine fois."
 UP_SKIP_UPDATE_QUESTION_LABEL="Êtes-vous sûr de vouloir ignorer la recherche d'une mise à jour d'Autodesk Fusion 360 ?"
 
 UP_QUESTION_LABEL="Une nouvelle version est sortie ! Voulez-vous mettre à jour maintenant ?"
 
 UP_NO_CONNECTION_WARNING_LABEL="La connexion au serveur n'a pas pu être établie ! La recherche de nouvelles mises à jour a été ignorée ! Veuillez vérifier votre connexion Internet !"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="Souhaitez-vous vérifier les mises à jour de Fusion 360 avant de le lancer ?"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 sera mis à jour vers une version plus récente ..."
 

--- a/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
+++ b/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
@@ -136,9 +136,8 @@ UP_QUESTION_LABEL="Une nouvelle version est sortie ! Voulez-vous mettre à jour
 
 UP_NO_CONNECTION_WARNING_LABEL="La connexion au serveur n'a pas pu être établie ! La recherche de nouvelles mises à jour a été ignorée ! Veuillez vérifier votre connexion Internet !"
 
-UP_PROGRESS_LABEL_1="Connexion au serveur..."
-UP_PROGRESS_LABEL_2="# Vérifier tous les fichiers .."
-UP_PROGRESS_LABEL_3="# Tous les fichiers sont vérifiés !"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 sera mis à jour vers une version plus récente ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/it-IT/locale-it.sh
+++ b/files/builds/stable-branch/locale/it-IT/locale-it.sh
@@ -136,9 +136,8 @@ UP_QUESTION_LABEL="Una nuova versione è stata rilasciata! Vuoi aggiornare ora?"
 
 UP_NO_CONNECTION_WARNING_LABEL="Impossibile stabilire la connessione al server! Il controllo dei nuovi aggiornamenti è stato saltato! Controlla la tua connessione Internet!"
 
-UP_PROGRESS_LABEL_1="Connessione al server ..."
-UP_PROGRESS_LABEL_2="# Controlla tutti i file .."
-UP_PROGRESS_LABEL_3="# Tutti i file sono stati controllati!"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 verrà aggiornato a una versione più recente ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/it-IT/locale-it.sh
+++ b/files/builds/stable-branch/locale/it-IT/locale-it.sh
@@ -129,14 +129,14 @@ SP_COMPLETED_CHECK_LABEL="Esegui Autodesk Fusion 360"
 
 UP_TITLE="Autodesk Fusion 360 per Linux - Avvio applicazioni"
 UP_NO_UPDATE_INFO_LABEL="Nessuna versione più recente trovata, quindi il tuo Autodesk fusion 360 è aggiornato!"
-UP_SKIP_INFO_LABEL="L'aggiornamento è stato ignorato! Aggiorna presto la tua versione di Autodesk Fusion 360!"
+UP_SKIP_INFO_LABEL="L'aggiornamento è stato saltato! Ti invitiamo a controllare gli aggiornamenti la prossima volta."
 UP_SKIP_UPDATE_QUESTION_LABEL="Sei sicuro di voler saltare la ricerca di un aggiornamento di Autodesk Fusion 360?"
 
 UP_QUESTION_LABEL="Una nuova versione è stata rilasciata! Vuoi aggiornare ora?"
 
 UP_NO_CONNECTION_WARNING_LABEL="Impossibile stabilire la connessione al server! Il controllo dei nuovi aggiornamenti è stato saltato! Controlla la tua connessione Internet!"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="Desideri verificare la disponibilità di aggiornamenti per Fusion 360 prima del lancio?"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 verrà aggiornato a una versione più recente ..."
 

--- a/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
+++ b/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
@@ -129,14 +129,14 @@ SP_COMPLETED_CHECK_LABEL="AutodeskFusion360を実行する"
 
 UP_TITLE="Autodesk Fusion 360 for Linux-Launcher"
 UP_NO_UPDATE_INFO_LABEL="新しいバージョンが見つからなかったため、Autodesk Fusion 360は最新です！"
-UP_SKIP_INFO_LABEL="更新はスキップされました！Autodesk Fusion 360のバージョンをすぐに更新してください！"
+UP_SKIP_INFO_LABEL="更新がスキップされました！ 次回はアップデートをチェックすることを検討してください。"
 UP_SKIP_UPDATE_QUESTION_LABEL="Autodesk Fusion 360アップデートの検索をスキップしてもよろしいですか？"
 
 UP_QUESTION_LABEL="新しいバージョンがリリースされました！今すぐ更新しますか？"
 
 UP_NO_CONNECTION_WARNING_LABEL="サーバーへの接続を確立できませんでした！新しい更新の確認はスキップされました！インターネット接続を確認してください！"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="Fusion 360 を起動する前に、そのアップデートを確認しますか?"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="AutodeskFusion360は新しいバージョンに更新されます ..."
 

--- a/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
+++ b/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
@@ -136,9 +136,8 @@ UP_QUESTION_LABEL="新しいバージョンがリリースされました！今�
 
 UP_NO_CONNECTION_WARNING_LABEL="サーバーへの接続を確立できませんでした！新しい更新の確認はスキップされました！インターネット接続を確認してください！"
 
-UP_PROGRESS_LABEL_1="サーバーに接続しています..."
-UP_PROGRESS_LABEL_2="＃すべてのファイルを確認してください.."
-UP_PROGRESS_LABEL_3="＃すべてのファイルがチェックされます！"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
 UP_INSTALL_UPDATE_PROGRESS_LABEL="AutodeskFusion360は新しいバージョンに更新されます ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
+++ b/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
@@ -136,9 +136,8 @@ UP_QUESTION_LABEL="새 버전이 출시되었습니다! 지금 업데이트하�
 
 UP_NO_CONNECTION_WARNING_LABEL="서버에 연결할 수 없습니다! 새 업데이트 확인을 건너뛰었습니다! 인터넷 연결을 확인하십시오!"
 
-UP_PROGRESS_LABEL_1="서버에 연결하는 중..."
-UP_PROGRESS_LABEL_2="# 모든 파일 확인 .."
-UP_PROGRESS_LABEL_3="# 모든 파일을 확인했습니다!"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360이 최신 버전으로 업데이트됩니다 ..."
 
 ###############################################################################################################################################################

--- a/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
+++ b/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
@@ -129,14 +129,14 @@ SP_COMPLETED_CHECK_LABEL="Autodesk Fusion 360 실행"
 
 UP_TITLE="Linux용 Autodesk Fusion 360 - 실행기"
 UP_NO_UPDATE_INFO_LABEL="최신 버전을 찾을 수 없으므로 Autodesk fusion 360이 최신 상태입니다!"
-UP_SKIP_INFO_LABEL="업데이트를 건너뛰었습니다! Autodesk Fusion 360 버전을 곧 업데이트하십시오!"
+UP_SKIP_INFO_LABEL="업데이트를 건너뛰었습니다! 다음 번에는 업데이트를 확인해 보세요."
 UP_SKIP_UPDATE_QUESTION_LABEL="Autodesk Fusion 360 업데이트 검색을 건너뛰시겠습니까?"
 
 UP_QUESTION_LABEL="새 버전이 출시되었습니다! 지금 업데이트하시겠습니까?"
 
 UP_NO_CONNECTION_WARNING_LABEL="서버에 연결할 수 없습니다! 새 업데이트 확인을 건너뛰었습니다! 인터넷 연결을 확인하십시오!"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="Fusion 360을 출시하기 전에 업데이트를 확인하시겠습니까?"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360이 최신 버전으로 업데이트됩니다 ..."
 

--- a/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
+++ b/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
@@ -129,14 +129,14 @@ SP_COMPLETED_CHECK_LABEL="运行 Autodesk Fusion 360"
 
 UP_TITLE="Autodesk Fusion 360 for Linux - 启动器"
 UP_NO_UPDATE_INFO_LABEL="未找到更新版本，因此您的 Autodesk fusion 360 是最新的！"
-UP_SKIP_INFO_LABEL="已跳过更新！请尽快更新您的 Autodesk Fusion 360 版本！"
+UP_SKIP_INFO_LABEL="更新被跳过！ 请考虑下次检查更新。"
 UP_SKIP_UPDATE_QUESTION_LABEL="您确定要跳过搜索 Autodesk Fusion 360 更新吗？"
 
 UP_QUESTION_LABEL="新版本已发布！您要立即更新吗？"
 
 UP_NO_CONNECTION_WARNING_LABEL="无法建立与服务器的连接！已跳过检查新更新！请检查您的互联网连接！"
 
-UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+UP_WANT_TO_CHECK_FOR_UPDATES="您想在启动之前检查 Fusion 360 的更新吗？"
 
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 将更新到更新版本 ..."
 

--- a/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
+++ b/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
@@ -136,9 +136,8 @@ UP_QUESTION_LABEL="新版本已发布！您要立即更新吗？"
 
 UP_NO_CONNECTION_WARNING_LABEL="无法建立与服务器的连接！已跳过检查新更新！请检查您的互联网连接！"
 
-UP_PROGRESS_LABEL_1="正在连接服务器 ..."
-UP_PROGRESS_LABEL_2="# 检查所有文件 ..."
-UP_PROGRESS_LABEL_3="#所有文件都被检查了！"
+UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
+
 UP_INSTALL_UPDATE_PROGRESS_LABEL="Autodesk Fusion 360 将更新到更新版本 ..."
 
 ###############################################################################################################################################################


### PR DESCRIPTION
## 📝 Description
While I was working on the fix I submitted for the issues raised in #363 I observed some areas where the Yad interface could be changed to improve the user experience and reduce some of the confusion I saw in #363, and possibly some other tickets. The changes I'm proposing _only_ affect the dialogs shown when starting the app, not the installation dialogs.

If my proposed changes don't align with where you're going in the development branch, happy to make changes.

### High-level changes

* Visual signposts (icons) used to help the user understand the purpose of the specific Yad dialog boxes during the app startup.
* Consistent button labels used for the different dialog types, inline with the type of dialog it is.
* Switched a progress panel to a question panel to fit the intended action better.

### Detailed changes

**Icons and buttons:**

* Where the dialog is for information (ie: there is no choice to make):
  * Dialog shows the information icon.
  * Dialog only shows an 'ok' button rather than "ok" and "cancel". The cancel button did the same thing as the 'ok' button.
* Where the dialog is asking a yes/no question:
  * Dialog shows the question icon.
  * Dialog shows 'no' and 'yes' buttons. The previous 'cancel' and 'ok' buttons are slighly ambiguous responses to the questions.
* Where a warning is being issue:
  * Dialog shows the warning icon.
  * As with the information dialog, dialog shows an 'ok' button only.

**Modified panel type:**

* Switched the 'Connecting to the server ...' progress bar panel to a question panel. This progress bar isn't showing any real progress - it uses built in timers to move the progress bar. The 'ok' and 'cancel' buttons cause the script to look for updates to Fusion 360 or skip that step. This isn't clear behavior.

**Changes to this dialog panel:**

* Panel now shows a question: 'Would you like to check for updates to Fusion360 before launching?'.
* The dialog shows a question icon.
* As with the other question dialog boxes, the dialog shows 'no' and 'yes' buttons.

**Implications of changing the panel for 'Connecting to the server'**

The proposed changes have an impact on the locale files:

* 3 unused lines have been removed from *all* locale files. The last 2 messages never actually appeared in the progress dialog.
  ```sh
  # Progress messages removed from all locale files 
  UP_PROGRESS_LABEL_1="Connecting to the server ..."
  UP_PROGRESS_LABEL_2="# Check all files .."
  UP_PROGRESS_LABEL_3="# All files are checked!"
  ```
* 1 line has been added to *all* locale files. I've used Google translate for each of the languages used.
  ```sh
  # New question added to all locale files
  UP_WANT_TO_CHECK_FOR_UPDATES="Would you like to check for updates to Fusion360 before launching?"
  ```

## 📑 Context

* Reduce confusion through clearer more consistent dialogs.
* Reduce "noise" in tickets created by confusion around these dialogs. 
* Better user experience.  
* The proposed improvements to the 'Connecting to server'  panel will speed up start up (no simulated progress bar delays), cause less confusion for those expecting the progress bar panel to vanish when it reaches 100% like the others do, better communicates the choice that the user is making with that dialog, and it may also reduce issues being lodged on GitHub from confused users.

## ✅ Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.

### 📸 Screenshots

Current progress panel:
![Current progress panel](https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/assets/90298030/15887c54-c3c7-4731-8e39-59590ee62372)

...proposed to be replaced with:
![Proposed update panel](https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/assets/90298030/bd038bca-8124-463c-b101-803ed1dcf100)
