### PR TITLE
Update install.sh :  Missing "$"

### DIFF
--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -325,7 +325,7 @@ function SP_FUSION360_INSTALLER_LOAD {
 function SP_WEBVIEW2_INSTALLER_LOAD {
   # Search for a existing installer of WEBVIEW2
   WEBVIEW2_INSTALLER="$SP_PATH/downloads/WebView2installer.exe"
-  if [ -f "WEBVIEW2_INSTALLER" ]; then
+  if [ -f "$WEBVIEW2_INSTALLER" ]; then
     echo "The WebView2installer installer exist!"
   else
     echo "The WebView2installer installer doesn't exist and will be downloaded for you!"


### PR DESCRIPTION
## 📝 Description
A "$" was missing in a "is file exist" syntax.

## 📑 Context
This was making the test failing and the script was downloading the installer each time, even if the installer file already exist.

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->

### 🔗 Link to story (if available)
<!--- Add story URL here -->
