### PR TITLE
docs(readme): update Fusion 360 Flatpak app link

### DIFF
--- a/README-cs_CZ.md
+++ b/README-cs_CZ.md
@@ -332,7 +332,7 @@
 
 🔹 Nebo si nainstalujete a použijete Autodesk Fusion 360 jako aplikaci Flatpak: 
 
-     https://usebottles.com/app/#fusion360
+     https://usebottles.com/app/#fusion
     
     
 🔹 Nyní můžete <a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">použít</a> Autodesk Fusion 360 na vašem systému Linux!

--- a/README-de_DE.md
+++ b/README-de_DE.md
@@ -334,7 +334,7 @@
 
 🔹 Oder Sie installieren und verwenden Autodesk Fusion 360 als Flatpak-App: 
 
-    https://usebottles.com/app/#fusion360
+    https://usebottles.com/app/#fusion
     
 🔹 Jetzt können Sie Autodesk Fusion 360 <a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">verwenden</a>!
   </br></br>

--- a/README-es_ES.md
+++ b/README-es_ES.md
@@ -333,7 +333,7 @@
 
 🔹  O instala y usa Autodesk Fusion 360 como una aplicación Flatpak:
 
-     https://usebottles.com/app/#fusion360
+     https://usebottles.com/app/#fusion
 
 🔹 Ahora, puede <a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">usar</a> Autodesk Fusion 360 en su sistema Linux!
   </br></br>

--- a/README-fr_FR.md
+++ b/README-fr_FR.md
@@ -332,7 +332,7 @@
 
 🔹 Ou vous installez et utilisez Autodesk Fusion 360 en tant qu'application Flatpak:
 
-     https://usebottles.com/app/#fusion360
+     https://usebottles.com/app/#fusion
 
 🔹 Maintenant, vous pouvez <a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">utiliser</a> Autodesk Fusion 360 sur votre système Linux !
   </br></br>

--- a/README-it_IT.md
+++ b/README-it_IT.md
@@ -332,7 +332,7 @@
 
 🔹  Oppure puoi installare e utilizzare Autodesk Fusion 360 come app Flatpak:
 
-     https://usebottles.com/app/#fusion360
+     https://usebottles.com/app/#fusion
     
 🔹 Ora puoi <a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">utilizzare</a> Autodesk Fusion 360 sul tuo sistema Linux!
   </br></br>

--- a/README-ja_JP.md
+++ b/README-ja_JP.md
@@ -332,7 +332,7 @@
 
 🔹または、AutodeskFusion360をFlatpakアプリとしてインストールして使用します。
 
-     https://usebottles.com/app/#fusion360
+     https://usebottles.com/app/#fusion
 
 🔹これで、AutodeskFusion360を<a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">使用</a>できるようになりました Linuxシステムで！
   </br> </br>

--- a/README-ko_KR.md
+++ b/README-ko_KR.md
@@ -332,7 +332,7 @@
 
 🔹  <del>또는 Autodesk Fusion 360을 Flatpak 앱으로 설치하여 사용합니다.</del> 
 
- <del>    https://usebottles.com/app/#fusion360 </del>
+ <del>    https://usebottles.com/app/#fusion </del>
 
 🔹 이제 Autodesk Fusion 360을 <a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">사용</a>할 수 있습니다. 당신의 리눅스 시스템에!
   </br></br>

--- a/README-ru_RU.md
+++ b/README-ru_RU.md
@@ -332,7 +332,7 @@
 
 🔹 Или вы устанавливаете и используете Autodesk Fusion 360 как приложение Flatpak: 
 
-    https://usebottles.com/app/#fusion360
+    https://usebottles.com/app/#fusion
 
 🔹 Теперь вы можете <a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">использовать</a> Autodesk Fusion 360. в вашей системе Linux!
   </br></br>

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -332,7 +332,7 @@
 
 🔹 或者您安装 Autodesk Fusion 360 并将其用作 Flatpak 应用程序：
 
-    https://usebottles.com/app/#fusion360    
+    https://usebottles.com/app/#fusion    
     
 🔹 现在，您可以<a href="https://github.com/cryinkfly/Fusion-360---Linux-Wine-Version-/issues/44#issuecomment-890552181">使用</a> Autodesk Fusion 360 在你的 Linux 系统上！
   </br></br>

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@
 
 🔹 Or you install and use Autodesk Fusion 360 as a Flatpak app:
 
-     https://usebottles.com/app/#fusion360
+     https://usebottles.com/app/#fusion
 
   For the SSO-Login bug use this Workaround: https://github.com/cryinkfly/Autodesk-Fusion-360-for-Linux/issues/460#issuecomment-2315888332
 


### PR DESCRIPTION
This commit updates the URL for installing Autodesk Fusion 360 as a Flatpak app across multiple README files in different languages. The URL has been changed from 'https://usebottles.com/app/#fusion360' to 'https://usebottles.com/app/#fusion'.

This change ensures that users are directed to the correct page for installing Fusion 360 using Bottles, improving the accuracy of the installation instructions in the project documentation.