### PR TITLE
Fix broken paths in dxvk_opengl_1()

### DIFF
--- a/files/setup/autodesk_fusion_installer_x86-64.sh
+++ b/files/setup/autodesk_fusion_installer_x86-64.sh
@@ -1098,9 +1098,9 @@ EOL
 function dxvk_opengl_1 {
     if [[ $GPU_DRIVER = "DXVK" ]]; then
         WINEPREFIX="$SELECTED_DIRECTORY/wineprefixes/default" sh "$SELECTED_DIRECTORY/bin/winetricks" -q dxvk
-        curl -L https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/setup/resource/video_driver/dxvk/DXVK.reg -o "$SELECTED_DIRECTORY/drive_c/users/$USER/Downloads/DXVK.reg"
+        curl -L https://raw.githubusercontent.com/cryinkfly/Autodesk-Fusion-360-for-Linux/main/files/setup/resource/video_driver/dxvk/DXVK.reg -o "$SELECTED_DIRECTORY/wineprefixes/default/drive_c/users/$USER/Downloads/DXVK.reg"
         # Add the "return"-option. Here you can read more about it -> https://github.com/koalaman/shellcheck/issues/592
-        cd "$SELECTED_DIRECTORY/drive_c/users/$USER/Downloads" || return
+        cd "$SELECTED_DIRECTORY/wineprefixes/default/drive_c/users/$USER/Downloads" || return
         WINEPREFIX="$SELECTED_DIRECTORY/wineprefixes/default" wine regedit.exe DXVK.reg
     fi
 }


### PR DESCRIPTION
The download destination of DXVK.reg should be inside the wine prefix of the installation.

## 📝 Description
Change paths in dxvk_opengl_1 to install DXVK.reg in `$SELECTED_DIRECTORY/drive_c/users/$USER/Downloads/`

## 📑 Context
Fixes #484 

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
<!--- Add screenshots here -->

### 🔗 Link to story (if available)
<!--- Add story URL here -->
