### PR TITLE
Change invocation of mokutil to return 0 on success

### DIFF
--- a/files/setup/autodesk_fusion_installer_x86-64.sh
+++ b/files/setup/autodesk_fusion_installer_x86-64.sh
@@ -143,7 +143,7 @@ check_required_packages() {
                     ;;
 
                 mokutil)
-                    if ! mokutil &>/dev/null; then
+                    if ! mokutil --list-enrolled &>/dev/null; then
                         echo -e "${RED}The required command (${cmd}) is not available!${NOCOLOR}"
                         MISSING_COMMANDS+=("$cmd")
                     else


### PR DESCRIPTION

## 📝 Description
Change the test invocation of mokutil to include the (hopefully benign) `--list-enrolled` option

## 📑 Context
Some versions of mokutil have an exit code of -1 when invoked without arguments, which causes the check for mokutil to fail and subsequent re-installation of required tools, regardless of whether they are already installed or not. This error also makes the script in "unsupported" distributions needlessly fail: if a user installs all tools by hand, the script would not detect the tools properly. As far as I can tell, the only distribution specific thing is installing dependencies via distribution-specific package managers.

Invoking mokutil with --version also results in an exit code of -1. This seems to have been fixed in mokutil 0.7.0: https://github.com/lcp/mokutil/commit/f68a4f43c0ec50b72936f66d90ebf4c84d09ecff

I'm on Ubuntu 24.04, running mokutil 0.6.0.

I think that this would at least fix the mokutil detection issue in #507.


## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
Not a picture but some commandline output:
```
hannesweisbach@Desktop:~/fusion$ mokutil --version
0.6.0
hannesweisbach@Desktop:~/fusion$ mokutil --version &> /dev/null ; echo $?
255
hannesweisbach@Desktop:~/fusion$ mokutil &> /dev/null ; echo $?
255
hannesweisbach@Desktop:~/fusion$ mokutil --list-enrolled &> /dev/null ; echo $?
0
```

### 🔗 Link to story (if available)
<!--- Add story URL here -->
