### PR TITLE
chore: Add CachyOS support

### DIFF
--- a/README-cs_CZ.md
+++ b/README-cs_CZ.md
@@ -205,7 +205,7 @@
      <td>
      <u>Linuxové distribuce</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README-de_DE.md
+++ b/README-de_DE.md
@@ -205,7 +205,7 @@
      <td>
      <u>Linux-Distributionen</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README-es_ES.md
+++ b/README-es_ES.md
@@ -205,7 +205,7 @@
      <td>
      <u>Distribuciones de Linux</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README-fr_FR.md
+++ b/README-fr_FR.md
@@ -205,7 +205,7 @@
      <td>
      <u>Distributions Linux</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README-it_IT.md
+++ b/README-it_IT.md
@@ -205,7 +205,7 @@
      <td >
      <u>Distribuzioni Linux</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README-ja_JP.md
+++ b/README-ja_JP.md
@@ -205,7 +205,7 @@
      <td>
      <u>Linuxディストリビューション</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README-ko_KR.md
+++ b/README-ko_KR.md
@@ -205,7 +205,7 @@
      <td>
      <u>Linux 배포판</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README-ru_RU.md
+++ b/README-ru_RU.md
@@ -205,7 +205,7 @@
      <td>
      <u>Дистрибутивы Linux</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -205,7 +205,7 @@
      <td>
      <u>Linux 发行版</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@
      <td>
      <u>Linux distributions</u>
       <ul>
-       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, ...</p></li>
+       <li><p>Arch Linux, Manjaro Linux, EndeavourOS, CachyOS, ...</p></li>
        <li><p>Debian 11, Raspberry Pi Desktop, ...</p></li>
        <li><p>Debian 12</p></li>
        <li><p>Debian Testing</p></li>

--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -1063,6 +1063,10 @@ case "$SP_OS" in
     echo "Arch Linux"
     OS_ARCHLINUX
     ;;
+  "CachyOS")
+    echo "CachyOS"
+    OS_ARCHLINUX
+    ;;
   "Debian 11")
     echo "Debian 11"
     DEBIAN_BASED_1

--- a/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
+++ b/files/builds/stable-branch/locale/cs-CZ/locale-cs.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Odstraňte aktuální Wineprefix ze svého
 SP_OS_TITLE="Linux distribuce - Konfigurace"
 SP_OS_LABEL_1="V tomto kroku nyní můžete vybrat svou distribuci Linuxu a nainstalovat potřebné balíčky pro instalaci."
 SP_OS_LABEL_2="Linux distribuce:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/de-DE/locale-de.sh
+++ b/files/builds/stable-branch/locale/de-DE/locale-de.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Entfernen Sie eine aktuelle Wineprefix von
 SP_OS_TITLE="Linux-Distribution - Konfiguration"
 SP_OS_LABEL_1="In diesem Schritt können Sie nun Ihre Linux-Distribution auswählen, um die benötigten Pakete für die Installation zu installieren."
 SP_OS_LABEL_2="Linux-Distribution:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/en-US/locale-en.sh
+++ b/files/builds/stable-branch/locale/en-US/locale-en.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Remove a current Wineprefix from your syst
 SP_OS_TITLE="Linux distribution - Configuration"
 SP_OS_LABEL_1="In this step you can now select your Linux distribution to install the required packages for the installation."
 SP_OS_LABEL_2="Linux distribution:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/es-ES/locale-es.sh
+++ b/files/builds/stable-branch/locale/es-ES/locale-es.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="¡Elimine un Wineprefix actual de su siste
 SP_OS_TITLE="Distribución Linux - Configuración"
 SP_OS_LABEL_1="En este paso ahora puede seleccionar su distribución de Linux para instalar los paquetes necesarios para la instalación."
 SP_OS_LABEL_2="Distribución de Linux:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
+++ b/files/builds/stable-branch/locale/fr-FR/locale-fr.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Supprimer un préfixe Wine actuel de votre
 SP_OS_TITLE="Distribution Linux - Configuration"
 SP_OS_LABEL_1="Dans cette étape, vous pouvez maintenant sélectionner votre distribution Linux pour installer les packages requis pour l'installation."
 SP_OS_LABEL_2="Répartition Linux :"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/it-IT/locale-it.sh
+++ b/files/builds/stable-branch/locale/it-IT/locale-it.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="Rimuovi un Wineprefix corrente dal tuo sis
 SP_OS_TITLE="Distribuzione Linux - Configurazione"
 SP_OS_LABEL_1="In questo passaggio puoi ora selezionare la tua distribuzione Linux per installare i pacchetti richiesti per l'installazione."
 SP_OS_LABEL_2="Distribuzione Linux:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
+++ b/files/builds/stable-branch/locale/ja-JP/locale-ja.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="システムから現在のWineprefixを�
 SP_OS_TITLE="Linuxディストリビューション-構成"
 SP_OS_LABEL_1="このステップでは、Linuxディストリビューションを選択して、インストールに必要なパッケージをインストールできます。"
 SP_OS_LABEL_2="Linuxディストリビューション："
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
+++ b/files/builds/stable-branch/locale/ko-KR/locale-ko.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="시스템에서 현재 Wineprefix를 제�
 SP_OS_TITLE="Linux 배포 - 구성"
 SP_OS_LABEL_1="이 단계에서는 이제 Linux 배포판을 선택하여 설치에 필요한 패키지를 설치할 수 있습니다."
 SP_OS_LABEL_2="Linux 배포판:"
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
+++ b/files/builds/stable-branch/locale/zh-CN/locale-zh.sh
@@ -60,7 +60,7 @@ SP_LOGFILE_WINEPREFIX_INFO_TOOLTIP_3="从您的系统中删除当前的 Winepref
 SP_OS_TITLE="Linux 发行版 - 配置"
 SP_OS_LABEL_1="在此步骤中，您现在可以选择您的 Linux 发行版来安装安装所需的软件包。"
 SP_OS_LABEL_2="Linux 发行版："
-SP_OS_SELECT=$(echo "Arch Linux,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
+SP_OS_SELECT=$(echo "Arch Linux,CachyOS,Debian 11,Debian 12, Debian Testing,EndeavourOS,Fedora 38,Fedora 39,Fedora Rawhide,Linux Mint 20.x,Linux Mint 21.x,Linux Mint 5.x - LMDE Version,Manjaro Linux,openSUSE Leap 15.4,openSUSE Leap 15.5,openSUSE Tumbleweed,Red Hat Enterprise Linux 8.x,Red Hat Enterprise Linux 9.x,Solus,Ubuntu 20.04,Ubuntu 22.04,Ubuntu 23.10,Void Linux,Gentoo Linux")
 
 ###############################################################################################################################################################
 

--- a/files/setup/autodesk_fusion_installer_x86-64.sh
+++ b/files/setup/autodesk_fusion_installer_x86-64.sh
@@ -182,7 +182,7 @@ function install_required_packages {
     echo -e "$(gettext "${YELLOW}The installer will install the required packages for the installation!")${NOCOLOR}"
     echo -e "$(gettext "${RED}Missing package: ${cmd}")${NOCOLOR}"
     sleep 2
-        if [[ $DISTRO_VERSION == *"arch"* ]] || [[ $DISTRO_VERSION == *"manjaro"* ]] || [[ $DISTRO_VERSION == *"endeavouros"* ]]; then
+        if [[ $DISTRO_VERSION == *"arch"* ]] || [[ $DISTRO_VERSION == *"manjaro"* ]] || [[ $DISTRO_VERSION == *"endeavouros"* ]] || [[ $DISTRO_VERSION == *"cachyos"* ]]; then
             echo -e "$(gettext "${YELLOW}All required packages for the installer will be installed!")${NOCOLOR}"
             sleep 2
             sudo pacman -S gawk cabextract coreutils curl lsb-release mesa-demos p7zip polkit samba spacenavd winbind wget xdg-utils bc xorg-xrandr --noconfirm
@@ -812,7 +812,7 @@ function check_and_install_wine() {
     # Check wine status 0 and install Wine version 
     if [ "$WINE_STATUS" -eq 0 ]; then
         DISTRO_VERSION=$(lsb_release -ds) # Check which Linux Distro is used! <-- Still in progress!!!
-        if [[ $DISTRO_VERSION == *"Arch"*"Linux"* ]] || [[ $DISTRO_VERSION == *"Manjaro"*"Linux"* ]] || [[ $DISTRO_VERSION == *"EndeavourOS"* ]]; then
+        if [[ $DISTRO_VERSION == *"Arch"*"Linux"* ]] || [[ $DISTRO_VERSION == *"Manjaro"*"Linux"* ]] || [[ $DISTRO_VERSION == *"EndeavourOS"* ]] || [[ $DISTRO_VERSION == *"CachyOS"* ]]; then
             echo "Installing Wine for Arch Linux ..."
             if grep -q '^\[multilib\]$' /etc/pacman.conf; then
                 echo "Multilib is already enabled!"

--- a/files/setup/data/autodesk_fusion_installer.sh
+++ b/files/setup/data/autodesk_fusion_installer.sh
@@ -209,7 +209,7 @@ function check_and_install_wine() {
 
     # Check wine status 0 and install Wine version 
     if [ "$wine_status" -eq 0 ]; then
-        if [[ $distribution == "arch" || $distribution == "manjaro" || $distribution == "endeavouros" ]]; then
+        if [[ $distribution == "arch" || $distribution == "manjaro" || $distribution == "endeavouros" || $distribution == "cachyos" ]]; then
             echo "Installing Wine for Arch Linux ..."
             if grep -q '^\[multilib\]$' /etc/pacman.conf; then
                 echo "Multilib is already enabled!"

--- a/files/setup/data/dev-installer.sh
+++ b/files/setup/data/dev-installer.sh
@@ -198,7 +198,7 @@ function check_and_install_wine() {
 
     # Check wine status 0 and install Wine version 
     if [ "$wine_status" -eq 0 ]; then
-        if [[ $distribution == "arch" || $distribution == "manjaro" || $distribution == "endeavouros" ]]; then
+        if [[ $distribution == "arch" || $distribution == "manjaro" || $distribution == "endeavouros" || $distribution == "cachyos" ]]; then
             echo "Installing Wine for Arch Linux ..."
             if grep -q '^\[multilib\]$' /etc/pacman.conf; then
                 echo "Multilib is already enabled!"


### PR DESCRIPTION
## 📝 Description
This adds CachyOS support.


## 📑 Context
Our users have reported that they not were able to install Fusion 360 with this script.
Adding CachyOS support makes it easier for the users.

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [x ] Tested the changes locally.
- [x ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.
