### PR TITLE
Updata wine version validation for wine 10.x

### DIFF
--- a/files/setup/autodesk_fusion_installer_x86-64.sh
+++ b/files/setup/autodesk_fusion_installer_x86-64.sh
@@ -796,7 +796,7 @@ function check_and_install_wine() {
         WINE_VERSION_MINOR_RELEASE="$(echo $WINE_VERSION | cut -d '.' -f2)"
         
         # Check if the installed wine version is at least 9.8 or higher (wine_version_series and wine_version_series_release)
-        if [ "$WINE_VERSION_MAJOR_RELEASE" -ge 9 ] && [ "$WINE_VERSION_MINOR_RELEASE" -ge 8 ]; then
+        if [ "$WINE_VERSION_MAJOR_RELEASE" -gt 9 ] || ([ "$WINE_VERSION_MAJOR_RELEASE" -eq 9 ] && [ "$WINE_VERSION_MINOR_RELEASE" -ge 8 ]); then
             echo "Wine version $WINE_VERSION is installed!"
             WINE_STATUS=1
         else


### PR DESCRIPTION
## 📝 Description
Fix detection for old wine version when wine version is above wine 9

## 📑 Context
Wine version 10 is detected as old version

## ✅ Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Updated tests for this change.
- [X] Tested the changes locally.
- [ ] Updated documentation.
- [ ] Change version number.
- [ ] Change the time and date.


### 📸 Screenshots (if available)
```
Everything is Ok           

Size:       140056584
Compressed: 42755243
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 71168  100 71168    0     0  1402k      0 --:--:-- --:--:-- --:--:-- 1418k
Wine is installed!
Wine version 10.0 is installed!
```
instead of:
```
Everything is Ok           

Size:       140056584
Compressed: 42755243
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 71168  100 71168    0     0  1062k      0 --:--:-- --:--:-- --:--:-- 1069k
Wine is installed!
Wine version 10.0 is installed, but this version is too old and will be updated for you!
```

### 🔗 Link to story (if available)
<!--- Add story URL here -->
